### PR TITLE
Fix miniplayer hidden while scrolling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "betteryt",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betteryt",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "license": "ISC",
       "devDependencies": {
-        "@types/chrome": "^0.0.304",
+        "@types/chrome": "^0.0.306",
         "copy-webpack-plugin": "^12.0.2",
         "css-loader": "^7.1.2",
         "mini-css-extract-plugin": "^2.9.2",
-        "sass": "^1.85.0",
+        "sass": "^1.85.1",
         "sass-loader": "^16.0.5",
         "ts-loader": "^9.5.2",
         "typescript": "^5.7.3",
@@ -457,9 +457,9 @@
       }
     },
     "node_modules/@types/chrome": {
-      "version": "0.0.304",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.304.tgz",
-      "integrity": "sha512-ms9CLILU+FEMK7gcmgz/Mtn2E81YQWiMIzCFF8ktp98EVNIIfoqaDTD4+ailOCq1sGjbnEmfJxQ1FAsQtk5M3A==",
+      "version": "0.0.306",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.306.tgz",
+      "integrity": "sha512-95kgcqvTNcaZCXmx/kIKY6uo83IaRNT3cuPxYqlB2Iu+HzKDCP4t7TUe7KhJijTdibcvn+SzziIcfSLIlgRnhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2129,9 +2129,9 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.85.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.85.0.tgz",
-      "integrity": "sha512-3ToiC1xZ1Y8aU7+CkgCI/tqyuPXEmYGJXO7H4uqp0xkLXUqp88rQQ4j1HmP37xSJLbCJPaIiv+cT1y+grssrww==",
+      "version": "1.85.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.85.1.tgz",
+      "integrity": "sha512-Uk8WpxM5v+0cMR0XjX9KfRIacmSG86RH4DCCZjLU2rFh5tyutt9siAXJ7G+YfxQ99Q6wrRMbMlVl6KqUms71ag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betteryt",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "Adds useful changes to YouTube, such as showing the mini player when scrolling.",
   "private": true,
   "scripts": {
@@ -17,11 +17,11 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/chrome": "^0.0.304",
+    "@types/chrome": "^0.0.306",
     "copy-webpack-plugin": "^12.0.2",
     "css-loader": "^7.1.2",
     "mini-css-extract-plugin": "^2.9.2",
-    "sass": "^1.85.0",
+    "sass": "^1.85.1",
     "sass-loader": "^16.0.5",
     "ts-loader": "^9.5.2",
     "typescript": "^5.7.3",

--- a/src/css/mini_player.scss
+++ b/src/css/mini_player.scss
@@ -12,6 +12,7 @@ body[betteryt-mini] {
   }
 
   .ytp-chrome-bottom {
+    display: unset !important;
     left: 1px !important;
     margin-bottom: 5px;
   }
@@ -30,6 +31,10 @@ body[betteryt-mini] {
   .expander.ytd-miniplayer,
   .index-message.ytd-miniplayer {
     display: none !important;
+  }
+
+  ytd-miniplayer {
+    display: unset !important;
   }
 
   .ytp-miniplayer-button {


### PR DESCRIPTION
Forces `display: unset` on the miniplayer so that it displays while scrolling.